### PR TITLE
fix: Incorrect contextmenu position when scroll exist

### DIFF
--- a/src/contextmenu.tsx
+++ b/src/contextmenu.tsx
@@ -31,10 +31,10 @@ const useContextMenu = (outerRef: React.RefObject<HTMLDivElement>) => {
       setXPos(`${event.pageX}px`);
       setYPos(`${event.pageY}px`);
       if (
-        outerRef.current!.getBoundingClientRect().top <= event.pageY &&
-        outerRef.current!.getBoundingClientRect().bottom >= event.pageY &&
-        outerRef.current!.getBoundingClientRect().left <= event.pageX &&
-        outerRef.current!.getBoundingClientRect().right >= event.pageX
+        outerRef.current!.getBoundingClientRect().top <= event.clientY &&
+        outerRef.current!.getBoundingClientRect().bottom >= event.clientY &&
+        outerRef.current!.getBoundingClientRect().left <= event.clientX &&
+        outerRef.current!.getBoundingClientRect().right >= event.clientX
       ) {
         event.preventDefault();
         showMenu(true);


### PR DESCRIPTION
issue: https://github.com/transcendence42/ft_transcendence/issues/127

- getBoundingClientRect is measured based on the viewport (starting with 0 in the top left), whereas the page indicates the position of the entire page, so the position is different when scrolling occurs. You need to change the standard to client, which is the same viewport standard as getBoundingClientRect.

> getBoundingClientRect properties other than width and height are relative to the top-left of the viewport.

- https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect

- before
```js
      if (
        outerRef.current!.getBoundingClientRect().top <= event.pageY &&
        outerRef.current!.getBoundingClientRect().bottom >= event.pageY &&
        outerRef.current!.getBoundingClientRect().left <= event.pageX &&
        outerRef.current!.getBoundingClientRect().right >= event.pageX
      ) {
```
- after
```js
      if (
        outerRef.current!.getBoundingClientRect().top <= event.clientY &&
        outerRef.current!.getBoundingClientRect().bottom >= event.clientY &&
        outerRef.current!.getBoundingClientRect().left <= event.clientX &&
        outerRef.current!.getBoundingClientRect().right >= event.clientX
      ) {
```